### PR TITLE
Add credential dashboard with modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import { Header } from './components/Header'
-import { Button } from './components/Button'
+import { CredentialsProvider } from './hooks/useCredentials'
+import { Dashboard } from './components/Dashboard'
 
 function App() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <Header />
-      <div className="flex items-center justify-center pt-10">
-        <Button variant="default" className="mr-2">Default</Button>
-        <Button variant="destructive">Destructive</Button>
+    <CredentialsProvider>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <Dashboard />
       </div>
-    </div>
+    </CredentialsProvider>
   )
 }
 

--- a/src/components/AddCredentialModal.jsx
+++ b/src/components/AddCredentialModal.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import { Button } from './Button'
+import { useCredentials } from '../hooks/useCredentials'
+
+function issueCredential(data) {
+  // Simulate Prism SDK issuing
+  return Promise.resolve({ id: Date.now().toString(), ...data })
+}
+
+export function AddCredentialModal() {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const { addCredential } = useCredentials()
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const cred = await issueCredential({ name })
+    addCredential(cred)
+    setName('')
+    setOpen(false)
+  }
+
+  if (!open) {
+    return <Button onClick={() => setOpen(true)}>Add Credential</Button>
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <form onSubmit={submit} className="bg-card rounded p-4 space-y-2 w-72">
+        <input
+          className="border w-full p-2 rounded"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+        />
+        <div className="flex justify-end space-x-2">
+          <Button type="button" variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button type="submit">Issue</Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useCredentials } from '../hooks/useCredentials'
+import { AddCredentialModal } from './AddCredentialModal'
+
+export function Dashboard() {
+  const { credentials } = useCredentials()
+
+  return (
+    <div className="p-4 space-y-4">
+      <AddCredentialModal />
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {credentials.map((cred) => (
+          <div key={cred.id} className="bg-card rounded p-4 shadow">
+            <p className="font-bold">{cred.name}</p>
+            <p className="text-sm text-muted-foreground">{cred.id}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useCredentials.js
+++ b/src/hooks/useCredentials.js
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
+
+const CredentialsContext = createContext()
+
+export function CredentialsProvider({ children }) {
+  const [credentials, setCredentials] = useState(() => {
+    const saved = localStorage.getItem('credentials')
+    return saved ? JSON.parse(saved) : []
+  })
+
+  useEffect(() => {
+    localStorage.setItem('credentials', JSON.stringify(credentials))
+  }, [credentials])
+
+  const addCredential = useCallback((cred) => {
+    setCredentials((prev) => [...prev, cred])
+  }, [])
+
+  return React.createElement(
+    CredentialsContext.Provider,
+    { value: { credentials, addCredential } },
+    children
+  )
+}
+
+export function useCredentials() {
+  return useContext(CredentialsContext)
+}

--- a/test/credentials.test.jsx
+++ b/test/credentials.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import React from 'react'
+import { CredentialsProvider } from '../src/hooks/useCredentials'
+import { Dashboard } from '../src/components/Dashboard'
+
+function Wrapper({ children }) {
+  return React.createElement(CredentialsProvider, null, children)
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('credential dashboard', () => {
+  it('creates and displays credential', async () => {
+    render(React.createElement(Dashboard), { wrapper: Wrapper })
+    fireEvent.click(screen.getByText('Add Credential'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Test' } })
+    fireEvent.click(screen.getByText('Issue'))
+    expect(await screen.findByText('Test')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add CredentialsProvider hook and context
- create AddCredentialModal and Dashboard components
- wire Dashboard into App
- test credential creation and display

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683fc2ddf334832dbed818dc0435e20a