### PR TITLE
Integrate Pollux issuance and update tests

### DIFF
--- a/src/lib/pollux.js
+++ b/src/lib/pollux.js
@@ -1,0 +1,7 @@
+export async function issueCredential(subjectDid, data) {
+  if (!subjectDid) {
+    throw new Error('No DID provided')
+  }
+  // Simulate Prism Pollux issuance
+  return { id: Date.now().toString(), subjectId: subjectDid, ...data }
+}

--- a/test/credentials.test.jsx
+++ b/test/credentials.test.jsx
@@ -1,8 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
 import React from 'react'
 import { CredentialsProvider } from '../src/hooks/useCredentials'
 import { Dashboard } from '../src/components/Dashboard'
+vi.mock('../src/lib/pollux', () => ({
+  issueCredential: vi.fn().mockResolvedValue({ id: '1', name: 'Test', subjectId: 'did:test' }),
+}))
+
+vi.mock('../src/hooks/useWallet', () => ({
+  useWallet: () => ({ did: 'did:test' }),
+}))
 
 function Wrapper({ children }) {
   return React.createElement(CredentialsProvider, null, children)


### PR DESCRIPTION
## Summary
- add Pollux SDK stub
- issue credentials via Pollux in AddCredentialModal and display errors
- mock Pollux issuance and wallet DID in credential tests

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fcb10f86c832d9f74561a3e9e002e