### PR TITLE
Annotate ZKP stubs and fix wallet tests

### DIFF
--- a/src/lib/zkp.js
+++ b/src/lib/zkp.js
@@ -1,15 +1,35 @@
+/**
+ * Generate a zero‑knowledge proof for the given credential.
+ *
+ * This implementation acts as a stub until the Midnight SDK
+ * is available. It simply returns a deterministic object so
+ * that the rest of the demo can operate.
+ *
+ * Expected behaviour when the SDK is integrated:
+ *   1. Use the Midnight prover to create a valid ZKP for the
+ *      supplied credential.
+ *   2. Return the proof in whatever format the verifier
+ *      requires.
+ */
 export async function generateProofForCredential(credential) {
-  // Placeholder for Midnight integration
   if (!credential) {
     throw new Error('Credential required')
   }
+  // In lieu of real proving logic we return a predictable object.
   return { proof: `proof-for-${credential.id}` }
 }
 
+/**
+ * Verify a zero‑knowledge proof.
+ *
+ * Currently this stub accepts any provided proof. With the
+ * Midnight SDK it should validate the proof and return the
+ * verification result.
+ */
 export async function verifyProof(proof) {
-  // Placeholder verification logic
   if (!proof) {
     throw new Error('Proof required')
   }
+  // Stubbed verification always succeeds for non‑null input.
   return true
 }

--- a/test/useWallet.test.js
+++ b/test/useWallet.test.js
@@ -4,12 +4,16 @@ import { useWallet } from '../src/hooks/useWallet'
 import * as prism from '../src/lib/prism'
 
 function mockWindow(enableImpl) {
-  global.window = Object.create(window)
-  global.window.cardano = { lace: { enable: enableImpl } }
+  // Preserve the jsdom window while injecting the cardano API
+  Object.defineProperty(global.window, 'cardano', {
+    configurable: true,
+    value: { lace: { enable: enableImpl } },
+  })
 }
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  delete global.window.cardano
 })
 
 describe('useWallet', () => {
@@ -37,7 +41,7 @@ describe('useWallet', () => {
   })
 
   it('sets error when wallet missing', async () => {
-    global.window = {}
+    delete global.window.cardano
     const { result } = renderHook(() => useWallet())
     await act(async () => {
       await result.current.connect()


### PR DESCRIPTION
## Summary
- document `generateProofForCredential` and `verifyProof` to indicate stubbed logic
- update wallet test helpers to avoid overwriting the jsdom window

## Testing
- `npx vitest run --config vite.config.js`

------
https://chatgpt.com/codex/tasks/task_e_685076eea444832d8890d14ec84a190f