### PR TITLE
Integrate Midnight ledger proof generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@atala/prism-wallet-sdk": "^5.2.0",
+        "@midnight-ntwrk/ledger": "^4.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "react": "^18.2.0",
@@ -3541,6 +3542,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@midnight-ntwrk/ledger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger/-/ledger-4.0.0.tgz",
+      "integrity": "sha512-cnJisY8uQ4NO54miDnjs/ov6n102ZPfKEPxtiDKVEdlKijcc70jz/CI2yBCc0itlwwaqma7FM2Ou5N4pWpbwbg=="
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
@@ -4809,6 +4815,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -4820,6 +4834,18 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
@@ -6335,6 +6361,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6369,6 +6405,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/custom-idle-queue": {
       "version": "3.0.1",
@@ -11997,7 +12041,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
       "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -12337,6 +12380,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {
@@ -13899,7 +13957,6 @@
       "version": "8.18.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13968,13 +14025,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "commonjs",
   "dependencies": {
     "@atala/prism-wallet-sdk": "^5.2.0",
+    "@midnight-ntwrk/ledger": "^4.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "react": "^18.2.0",

--- a/src/components/CredentialCard.jsx
+++ b/src/components/CredentialCard.jsx
@@ -14,7 +14,10 @@ export function CredentialCard({ cred }) {
     try {
       const p = await generateProofForCredential(cred)
       setProof(p)
-      setModal({ title: 'Proof Generated', message: JSON.stringify(p) })
+      setModal({
+        title: 'Proof Generated',
+        message: JSON.stringify(p, null, 2),
+      })
     } catch (err) {
       setModal({ title: 'Generation Failed', message: err.message })
     } finally {

--- a/src/lib/zkp.js
+++ b/src/lib/zkp.js
@@ -11,12 +11,24 @@
  *   2. Return the proof in whatever format the verifier
  *      requires.
  */
+import {
+  sampleSigningKey,
+  signData,
+  signatureVerifyingKey,
+  verifySignature,
+} from '@midnight-ntwrk/ledger'
+
+const signingKey = sampleSigningKey()
+const verifyingKey = signatureVerifyingKey(signingKey)
+const encoder = new TextEncoder()
+
 export async function generateProofForCredential(credential) {
   if (!credential) {
     throw new Error('Credential required')
   }
-  // In lieu of real proving logic we return a predictable object.
-  return { proof: `proof-for-${credential.id}` }
+  const payload = encoder.encode(JSON.stringify(credential))
+  const signature = signData(signingKey, payload)
+  return { credential, signature, verifyingKey }
 }
 
 /**
@@ -30,6 +42,10 @@ export async function verifyProof(proof) {
   if (!proof) {
     throw new Error('Proof required')
   }
-  // Stubbed verification always succeeds for non‑null input.
-  return true
+  const { credential, signature, verifyingKey: vk } = proof
+  if (!credential || !signature || !vk) {
+    throw new Error('Invalid proof format')
+  }
+  const payload = encoder.encode(JSON.stringify(credential))
+  return verifySignature(vk, payload, signature)
 }

--- a/test/zkp.test.js
+++ b/test/zkp.test.js
@@ -2,14 +2,22 @@ import { describe, it, expect } from 'vitest'
 import { generateProofForCredential, verifyProof } from '../src/lib/zkp'
 
 describe('zkp helpers', () => {
-  it('generates proof for credential', async () => {
-    const proof = await generateProofForCredential({ id: '123' })
-    expect(proof).toEqual({ proof: 'proof-for-123' })
+  it('generates and verifies proof for credential', async () => {
+    const cred = { id: '123', name: 'Test' }
+    const proof = await generateProofForCredential(cred)
+    expect(proof.credential).toEqual(cred)
+    expect(typeof proof.signature).toBe('string')
+    expect(typeof proof.verifyingKey).toBe('string')
+    const result = await verifyProof(proof)
+    expect(result).toBe(true)
   })
 
-  it('verifies proof', async () => {
-    const result = await verifyProof({ proof: 'anything' })
-    expect(result).toBe(true)
+  it('fails verification when credential mutated', async () => {
+    const cred = { id: 'a' }
+    const proof = await generateProofForCredential(cred)
+    const tampered = { ...proof, credential: { id: 'b' } }
+    const ok = await verifyProof(tampered)
+    expect(ok).toBe(false)
   })
 
   it('throws when proof missing', async () => {


### PR DESCRIPTION
## Summary
- add `@midnight-ntwrk/ledger` dependency
- implement real proof signing and verification in `zkp.js`
- display pretty printed proof in `CredentialCard`
- test proof creation and tampering scenarios

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68508205f014832db1ab51c56bd85cd6