### PR TITLE
Configure wallet network via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Run the test suite:
 npm test
 ```
 
+### Configuration
+
+The expected Cardano network ID can be configured using the
+`VITE_EXPECTED_NETWORK_ID` environment variable. If not provided it defaults
+to `0` (pre-production).
+
 ## Linting
 
 Use ESLint to verify code style:

--- a/src/hooks/useWallet.js
+++ b/src/hooks/useWallet.js
@@ -1,6 +1,11 @@
 import { useState, useCallback } from 'react'
 import { createOrLoadDID } from '../lib/prism'
 
+const EXPECTED_NETWORK_ID = parseInt(
+  import.meta.env.VITE_EXPECTED_NETWORK_ID || '0',
+  10
+)
+
 export function useWallet() {
   const [connected, setConnected] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -21,8 +26,10 @@ export function useWallet() {
         throw new Error('Wallet missing required capabilities')
       }
       const networkId = await walletApi.getNetworkId()
-      if (networkId !== 0) {
-        throw new Error('Unsupported network')
+      if (networkId !== EXPECTED_NETWORK_ID) {
+        throw new Error(
+          `Unsupported network: expected ${EXPECTED_NETWORK_ID}, got ${networkId}`
+        )
       }
       const rewards = await walletApi.getRewardAddresses()
       if (rewards && rewards[0]) {


### PR DESCRIPTION
## Summary
- make expected network configurable with `VITE_EXPECTED_NETWORK_ID`
- clarify unsupported network errors in `useWallet`
- document the new configuration in the README

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68508207b080832d9149b49286de5578