### PR TITLE
Switch to module package type

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "@atala/prism-wallet-sdk": "^5.2.0",
     "@midnight-ntwrk/ledger": "^4.0.0",


### PR DESCRIPTION
## Summary
- use ES module package type in package.json

## Testing
- `npm test` *(fails: Failed to load PostCSS config: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6856c13f6a40832d969406251f7c2a4d